### PR TITLE
Add check if media downloadable

### DIFF
--- a/lib/grammers-client/src/client/files.rs
+++ b/lib/grammers-client/src/client/files.rs
@@ -172,6 +172,9 @@ impl Client {
                 }
             }
         }
+        if downloadable.to_input_location().is_none() {
+            return Err(io::Error::new(io::ErrorKind::Other, "media not downloadable"));
+        }
 
         let mut download = self.iter_download(downloadable);
         Client::load(path, &mut download).await


### PR DESCRIPTION
## Issue

```rs
thread 'main' panicked at /home/imxeren/.cargo/git/checkouts/grammers-b702bdb11c87df45/e4116c7/lib/grammers-client/src/client/files.rs:37:87:
called `Option::unwrap()` on a `None` value
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

On update handler, the method panics if the media isn't downloadable for example, in case of polls etc. Looking on the description, 

```
Download the message media in this message if applicable.

Returns true if there was media to download, or false otherwise.
```
I guess that it shouldn't panic and return an `Err` and ultimately returns false on `message.download_media()`.

## Possible Solution

On navigating, I notice that the issue is how the method handles the download by invoking `downloadable.to_input_location()` which returns `None`. So, a check inside the `fn download_media` and returns `Err` if `downloadable.to_input_location()` is `None`, can possibly fix this.